### PR TITLE
Add Coinbase balance and outstanding order balances to orders page

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,7 @@
 coinbaseorders
 ==============
 
-Coinbase Limit Orders app 
+Coinbase Limit Orders app
 http://coinbaseorders.com/
 
 The app is based on Nette Framework http://nette.org/ . Nette was chosen for its security: http://doc.nette.org/en/2.1/vulnerability-protection
@@ -9,7 +9,7 @@ The app is based on Nette Framework http://nette.org/ . Nette was chosen for its
 PHP >= 5.3 is required.
 
 *** FIRST RUN
-1, Make directories `temp` and `log` writable. 
+1, Make directories `temp` and `log` writable.
 2, Copy /app/config/config.local.neon.sample to /app/config/config.local.neon
 3, Create a new MySQL database and run database-setup.sql on it
 4, Edit the newly copied file /app/config/config.local.neon:
@@ -17,7 +17,7 @@ PHP >= 5.3 is required.
 	- set your Coinbase Application API keys and URL. Get these on Coinbase.com. You might need to create a new application
 	- set some random SALT
 5, Set up your vhost to point to `www/www` directory (where index.php file is located)
-
+    - open your browser and verify that you can access the homepage and the donate sub-page
 
 *** CRON
 Currently the app relies on independent cron opening a page "/api/cron" once a minute to check orders. If you installed the app locally, you need to set up a cron such as this:
@@ -26,3 +26,7 @@ Currently the app relies on independent cron opening a page "/api/cron" once a m
 
 *** DEV ENVIRONMENT
 I use Netbeans 7.2 with a Nette Framework extension.
+
+*** Tips for installing on Mac OS X
+- Installing PHP, MySQL, and Apache: http://jason.pureconcepts.net/2012/10/install-apache-php-mysql-mac-os-x/
+- Installing mcrypt: http://coolestguidesontheplanet.com/install-mcrypt-php-mac-osx-10-9-mavericks-development-server/

--- a/www/app/model/DB/OrdersModel.php
+++ b/www/app/model/DB/OrdersModel.php
@@ -35,6 +35,24 @@ class OrdersModel extends BaseDbModel {
 		return $this->findAll()->get($id);
 	}
 
+	public function findExposure($user_id, $action) {
+		$sqlWhere = Array('status' => 'ACTIVE', 'user_id' => $user_id, 'action' => $action);
+		$exposure = $this->findAll()->where($sqlWhere)->sum("amount");
+
+		if(empty($exposure)) {
+			$exposure = 0;
+		}
+		return $exposure;
+	}
+
+	public function findSellExposure($user_id) {
+		return $this->findExposure($user_id, 'SELL');
+	}
+
+	public function findBuyExposure($user_id) {
+		return $this->findExposure($user_id, 'BUY');
+	}
+
 	public function insert($values) {
 		return $this->findAll()->insert($values);
 	}

--- a/www/app/presenters/BasePresenter.php
+++ b/www/app/presenters/BasePresenter.php
@@ -1,4 +1,3 @@
-
 <?php
 
 use Nette\Utils\Html;
@@ -26,20 +25,21 @@ abstract class BasePresenter extends Nette\Application\UI\Presenter {
 			'buy' => $this->context->values->get('coinbase', 'buyPrice'),
 			'sell' => $this->context->values->get('coinbase', 'sellPrice'),
 		);
-		
+
+		// Handle OAuth2 redirect from Coinbase
 		if ($this->getParam('code') != NULL && $this->user->isLoggedIn()) {
 			$this->context->coinbase->user($this->user->id)->getAndSaveTokens($this->getParam('code'));
 			$this->redirect($this->home);
 		}
 	}
-	
+
 	public function handleUpdateCurrentPrice(){
 		$updatedSecondsAgo = time() - $this->context->values->get('coinbase', 'sellPrice')->updated->getTimestamp();
-		
-		if($updatedSecondsAgo > 600){ //price not updated for more than 10 minutes
+
+		if($updatedSecondsAgo > 600 && Nette\Environment::isProduction()){ //price not updated for more than 10 minutes
 			throw new Exception('Price not updated for more than 10 minutes');
 		}
-		
+
 		$this->payload->currentBuyPrice = 'Buy $'.number_format($this->context->values->get('coinbase', 'buyPrice')->value, 2);
 		$this->payload->currentSellPrice = 'Sell $'.number_format($this->context->values->get('coinbase', 'sellPrice')->value, 2);
 		$this->payload->lastPriceCheck = "Price updated $updatedSecondsAgo seconds ago";

--- a/www/app/presenters/HomepagePresenter.php
+++ b/www/app/presenters/HomepagePresenter.php
@@ -6,7 +6,14 @@
 class HomepagePresenter extends BasePresenter {
 
 	public function renderDefault($code = NULL) {
-		
+	}
+
+	public function renderOrders() {
+		$this->template->btc_balance = number_format($this->context->coinbase->user($this->user->id)->getBalance(), 4);
+		$this->template->btc_sell_total = number_format($this->context->orders->findSellExposure($this->user->id), 4);
+		$this->template->btc_available = number_format($this->template->btc_balance - $this->template->btc_sell_total, 4);
+		$this->template->btc_buy_total = number_format($this->context->orders->findBuyExposure($this->user->id), 4);
+
 	}
 
 	public function actionOrders() {
@@ -30,14 +37,14 @@ class HomepagePresenter extends BasePresenter {
 			}
 		}
 	}
-	
+
 	public function renderAdmin(){
 		if(!$this->user->isInRole('ADMIN')){
 			$this->flashMessage('Not authorized', 'error');
 			$this->redirect($this->home);
 		}
 	}
-	
+
 	public function actionDisconnectFromCoinbase(){
 		if($this->user->isLoggedIn()){
 			$this->context->authenticator->update($this->user->id, Array(
@@ -46,7 +53,7 @@ class HomepagePresenter extends BasePresenter {
 				'coinbase_expire_time' => NULL,
 			));
 			$this->flashMessage('Coinbase disconnected. The app will not be able to fulfill any orders until you reconnect it.', 'success');
-			$this->redirect($this->home);			
+			$this->redirect($this->home);
 		}
 	}
 

--- a/www/app/templates/Homepage/orders.latte
+++ b/www/app/templates/Homepage/orders.latte
@@ -1,8 +1,32 @@
+{block head}
+<link rel="stylesheet" media="screen,projection,tv" href="{$basePath}/css/orders.css" />
+{/block}
+
 {block content}
 <h1>Orders</h1>
- 
+<table class="balances table table-bordered">
+    <tr>
+        <td class="title">Coinbase Balance</td>
+        <td class="amount">{$btc_balance} BTC</td>
+    </tr>
+    <tr>
+        <td class="title">Sell orders</td>
+        <td class="amount">{$btc_sell_total} BTC</td>
+    </tr>
+    <tr>
+        <td class="title">Available Balance</td>
+        <td class="amount">{$btc_available} BTC</td>
+    </tr>
+    <tr>
+        <td class="title">Buy orders</td>
+        <td class="amount">{$btc_buy_total} BTC</td>
+    </tr>
+</table>
+
 <a n:href="newOrder" class="btn btn-success btn-large"><i class="icon-white icon-plus"></i> Place new order</a>
 
 {widget OrdersGrid}
 
 <p>Price on Coinbase is checked about every second against your orders. Last check on {$latestPrice['buy']->updated} PST</p>
+
+

--- a/www/www/css/orders.css
+++ b/www/www/css/orders.css
@@ -1,0 +1,17 @@
+
+table.balances {
+    width: 450px;
+}
+
+td.title {
+    font-weight: bold;
+}
+
+td.amount {
+    text-align: right;
+    font-family: 'Courier New', monospace;
+}
+
+h1 {
+    padding-bottom: 5px;
+}


### PR DESCRIPTION
My text editor automatically removes extra whitespace at the end of lines.

Here is a screenshot of what this looks like.  Note the available balance can go negative because the page does not check of sufficient funds when setting up a sell order.

![screen shot 2014-02-26 at 8 23 46 pm](https://f.cloud.github.com/assets/2415796/2279187/17240876-9f67-11e3-9c09-0b56b8b62cf6.png)

Also, now that I'm taking another look at it, it would be nice to add a 3rd column which displays the price in USD.
