### PR TITLE
Add global stats to logged out homepage

### DIFF
--- a/www/app/model/Authenticator.php
+++ b/www/app/model/Authenticator.php
@@ -102,18 +102,25 @@ class Authenticator extends Nette\Object implements Security\IAuthenticator {
 			return $user->user_id;
 		}
 	}
-	
+
+	/**
+	 * Counts the number of confirmed users. This is a heavy operation.
+	 */
+	public function getCountConfirmedUsers() {
+		return $this->database->table(self::TABLE_NAME)->where(Array('email_confirmation' => 'confirmed'))->count();
+	}
+
 	public function setRandomHash($userId){
 		$randomHash = (string)$this->context->salted->hash(time().  rand(0, 10000000).$userId);
 		$this->update($userId, Array('random_hash' => $randomHash));
 		return $randomHash;
 	}
-	
+
 	public function verifyRandomHash($userId, $randomHash){
 		$user = $this->getUser($userId);
 		return ($randomHash && $user && $user->random_hash == $randomHash);
 	}
-		
+
 	public function resetPassword($userId, $randomHash, $newPassword){
 		if($this->verifyRandomHash($userId, $randomHash)){
 			$this->update($userId, Array(

--- a/www/app/model/DB/OrdersModel.php
+++ b/www/app/model/DB/OrdersModel.php
@@ -56,6 +56,7 @@ class OrdersModel extends BaseDbModel {
 	/**
 	 * Calculates active/executed buy/sell orders.
 	 * This is a heavy operation.
+	 * @return Nette\Database\Table\ActiveRow
 	 */
 	public function calculateOrderStats() {
 		$statsQuery = "
@@ -77,21 +78,7 @@ class OrdersModel extends BaseDbModel {
 			WHERE
 				status = 'ACTIVE' OR status = 'EXECUTED'";
 
-		$row = $this->database->query($statsQuery)->execute();
-		return Array(
-			"activeBuyCount" => $row->fetchField("activeBuyCount"),
-			"activeBuyBTCSum" => $row->fetchField("activeBuyBTCSum"),
-			"activeBuyUSDSum" => $row->fetchField("activeBuyUSDSum"),
-			"activeSellCount" => $row->fetchField("activeSellCount"),
-			"activeSellBTCSum" => $row->fetchField("activeSellBTCSum"),
-			"activeSellUSDSum" => $row->fetchField("activeSellUSDSum"),
-			"executedBuyCount" => $row->fetchField("executedBuyCount"),
-			"executedBuyBTCSum" => $row->fetchField("executedBuyBTCSum"),
-			"executedBuyUSDSum" => $row->fetchField("executedBuyUSDSum"),
-			"executedSellCount" => $row->fetchField("executedSellCount"),
-			"executedSellBTCSum" => $row->fetchField("executedSellBTCSum"),
-			"executedSellUSDSum" => $row->fetchField("executedSellUSDSum")
-		);
+		return $this->database->query($statsQuery)->fetch();
 	}
 
 	public function insert($values) {

--- a/www/app/model/DB/OrdersModel.php
+++ b/www/app/model/DB/OrdersModel.php
@@ -53,6 +53,47 @@ class OrdersModel extends BaseDbModel {
 		return $this->findExposure($user_id, 'BUY');
 	}
 
+	/**
+	 * Calculates active/executed buy/sell orders.
+	 * This is a heavy operation.
+	 */
+	public function calculateOrderStats() {
+		$statsQuery = "
+			SELECT
+				SUM(IF(status = 'ACTIVE' AND action = 'BUY',1,0)) as activeBuyCount,
+				SUM(IF(status = 'ACTIVE' AND action = 'BUY',amount,0)) as activeBuyBTCSum,
+				SUM(IF(status = 'ACTIVE' AND action = 'BUY',amount_currency,0)) as activeBuyUSDSum,
+				SUM(IF(status = 'ACTIVE' AND action = 'SELL',1,0)) as activeSellCount,
+				SUM(IF(status = 'ACTIVE' AND action = 'SELL',amount,0)) as activeSellBTCSum,
+				SUM(IF(status = 'ACTIVE' AND action = 'SELL',amount_currency,0)) as activeSellUSDSum,
+				SUM(IF(status = 'EXECUTED' AND action = 'BUY',1,0)) as executedBuyCount,
+				SUM(IF(status = 'EXECUTED' AND action = 'BUY',amount,0)) as executedBuyBTCSum,
+				SUM(IF(status = 'EXECUTED' AND action = 'BUY',amount_currency,0)) as executedBuyUSDSum,
+				SUM(IF(status = 'EXECUTED' AND action = 'SELL',1,0)) as executedSellCount,
+				SUM(IF(status = 'EXECUTED' AND action = 'SELL',amount,0)) as executedSellBTCSum,
+				SUM(IF(status = 'EXECUTED' AND action = 'SELL',amount_currency,0)) as executedSellUSDSum
+			FROM
+				orders
+			WHERE
+				status = 'ACTIVE' OR status = 'EXECUTED'";
+
+		$row = $this->database->query($statsQuery)->execute();
+		return Array(
+			"activeBuyCount" => $row->fetchField("activeBuyCount"),
+			"activeBuyBTCSum" => $row->fetchField("activeBuyBTCSum"),
+			"activeBuyUSDSum" => $row->fetchField("activeBuyUSDSum"),
+			"activeSellCount" => $row->fetchField("activeSellCount"),
+			"activeSellBTCSum" => $row->fetchField("activeSellBTCSum"),
+			"activeSellUSDSum" => $row->fetchField("activeSellUSDSum"),
+			"executedBuyCount" => $row->fetchField("executedBuyCount"),
+			"executedBuyBTCSum" => $row->fetchField("executedBuyBTCSum"),
+			"executedBuyUSDSum" => $row->fetchField("executedBuyUSDSum"),
+			"executedSellCount" => $row->fetchField("executedSellCount"),
+			"executedSellBTCSum" => $row->fetchField("executedSellBTCSum"),
+			"executedSellUSDSum" => $row->fetchField("executedSellUSDSum")
+		);
+	}
+
 	public function insert($values) {
 		return $this->findAll()->insert($values);
 	}

--- a/www/app/model/DB/ValuesModel.php
+++ b/www/app/model/DB/ValuesModel.php
@@ -39,6 +39,11 @@ class ValuesModel extends BaseDbModel {
 		return $this->findAll()->where(Array('group' => $group, 'name' => $name))->fetch();
 	}
 
+	/** @return array */
+	public function getGroup($group) {
+		return $this->findAll()->where(Array('group' => $group))->fetchPairs("name", "value");
+	}
+
 	public function getDateTime($group, $name) {
 		$value = $this->get($group, $name);
 		if (empty($value)) {

--- a/www/app/presenters/ApiPresenter.php
+++ b/www/app/presenters/ApiPresenter.php
@@ -7,13 +7,21 @@
  */
 class ApiPresenter extends BasePresenter {
 
+	/**
+	 * Called every minute
+	 */
 	public function renderCron() {
-		$initialTime = time();		
-		//runs repeatedly for 55 seconds
-		while(time() - $initialTime < 55){
-			$this->checkActiveOrders();
-			sleep(3);
-		}
+		$initialTime = time();
+
+		$this->possiblyUpdateGlobalSummaryStats();
+
+		// STOPSHIP(mattfaus): DEBUG ONLY
+		// Check and execute active orders every 3 seconds
+		// while(time() - $initialTime < 55){
+		// 	$this->checkActiveOrders();
+		// 	// TODO(mattfaus): We should sleep less if order execution took a long time
+		// 	sleep(3);
+		// }
 	}
 
 	private function checkActiveOrders() {
@@ -26,17 +34,15 @@ class ApiPresenter extends BasePresenter {
 
 		$currentSellPrice = $this->context->coinbasePrice->getSellPrice();
 		if (!empty($currentSellPrice)) {
-			$this->context->values->update('coinbase', 'sellPrice', (string) $currentSellPrice);	
+			$this->context->values->update('coinbase', 'sellPrice', (string) $currentSellPrice);
 		}
-		
+
 		if (!empty($currentBuyPrice)) {
 			$this->checkBuyOrders($currentBuyPrice);
 		}
 		if (!empty($currentSellPrice)) {
 			$this->checkSellOrders($currentSellPrice);
 		}
-		
-		
 	}
 
 	public function checkBuyOrders($currentBuyPrice) {
@@ -48,8 +54,8 @@ class ApiPresenter extends BasePresenter {
 				if ($totalBuyPrice !== NULL && $totalBuyPrice->subtotal->amount <= $order->at_price * $order->amount) {
 					$result = $this->context->coinbase->user($order->user_id)->order($order)->buy($order->amount); //Buy the coins
 					$this->context->orders->findAll()->get($order->order_id)->update(Array('status' => 'EXECUTED')); //Update order status
-					
-					new SendEmail($userAssociatedWithOrder->email, 'You just bought Bitcoin using limit order on Coinbase!', 'Hi there!<br/><br/>The system just executed your order to buy Bitcoin. You can check the details at <a href="http://coinbaseorders.com/">http://coinbaseorders.com/</a>.<br/><br/>Coinbase Orders is a free service. Please consider a small donation, others have donated too. The donation address is 13ejFczTyMsdZQHkrfVEfiGY8RLD2rDs9i, alternatively <a href="http://coinbaseorders.com/homepage/donate">click here to get donation QR code</a>.<br/><br/>I appriciate your help!<br/><br/>Tom');				
+
+					new SendEmail($userAssociatedWithOrder->email, 'You just bought Bitcoin using limit order on Coinbase!', 'Hi there!<br/><br/>The system just executed your order to buy Bitcoin. You can check the details at <a href="http://coinbaseorders.com/">http://coinbaseorders.com/</a>.<br/><br/>Coinbase Orders is a free service. Please consider a small donation, others have donated too. The donation address is 13ejFczTyMsdZQHkrfVEfiGY8RLD2rDs9i, alternatively <a href="http://coinbaseorders.com/homepage/donate">click here to get donation QR code</a>.<br/><br/>I appriciate your help!<br/><br/>Tom');
 				}
 			}
 		}
@@ -59,7 +65,7 @@ class ApiPresenter extends BasePresenter {
 		$sqlWhere = Array('status' => 'ACTIVE', 'action' => 'SELL', "$currentSellPrice >= `at_price`");
 		foreach ($this->context->orders->findAll()->where($sqlWhere) as $order) { //double check the price for each before selling
 			$userAssociatedWithOrder = $this->context->authenticator->getUser($order->user_id);
-			if(!empty($order->at_price) && !empty($order->amount) && $userAssociatedWithOrder->coinbase_access_token){ //his Coinbase API tokens are set			
+			if(!empty($order->at_price) && !empty($order->amount) && $userAssociatedWithOrder->coinbase_access_token){ //his Coinbase API tokens are set
 				$totalSellPrice = $this->context->coinbase->user($order->user_id)->order($order)->getSellPrice($order->amount);
 				if ($totalSellPrice !== NULL && $totalSellPrice->subtotal->amount >= $order->at_price * $order->amount) {
 					$result = $this->context->coinbase->user($order->user_id)->order($order)->sell($order->amount); //Sell the coins
@@ -68,6 +74,32 @@ class ApiPresenter extends BasePresenter {
 					new SendEmail($userAssociatedWithOrder->email, 'You just sold Bitcoin using limit order on Coinbase!', 'Hi there!<br/><br/>The system just executed your order to buy Bitcoin. You can check the details at <a href="http://coinbaseorders.com/">http://coinbaseorders.com/</a>.<br/><br/>Coinbase Orders is a free service. Please consider a small donation, others have donated too. The donation address is 13ejFczTyMsdZQHkrfVEfiGY8RLD2rDs9i, alternatively <a href="http://coinbaseorders.com/homepage/donate">click here to get donation QR code</a>.<br/><br/>I appriciate your help!<br/><br/>Tom');
 				}
 			}
+		}
+	}
+
+	/**
+	 * Checks to see when the last time global stats were updated, and
+	 * if that was longer than 10 minutes ago, re-updates them.
+	 */
+	private function possiblyUpdateGlobalSummaryStats() {
+		$updateInterval = new DateInterval("PT10M");
+		$lastUpdateTime = $this->context->values->getDateTime("globalStats", "lastUpdateTime");
+		$now = new DateTime();
+
+		if (!$lastUpdateTime) {
+			$nextUpdateTime = $now;
+		} else {
+			$nextUpdateTime = $lastUpdateTime->add($updateInterval);
+		}
+
+		$confirmed_users = $this->context->authenticator->getCountConfirmedUsers();
+		$stats = $this->context->orders->calculateOrderStats();
+		\Nette\Diagnostics\Debugger::dump($stats);
+
+		if ($nextUpdateTime <= $now) {
+			// amount of registered users, amount of active orders, amount of executed orders to date
+			\Nette\Diagnostics\Debugger::dump("Updating!");
+			$this->context->values->updateDateTime("globalStats", "lastUpdateTime", $now);
 		}
 	}
 

--- a/www/app/presenters/ApiPresenter.php
+++ b/www/app/presenters/ApiPresenter.php
@@ -92,14 +92,16 @@ class ApiPresenter extends BasePresenter {
 			$nextUpdateTime = $lastUpdateTime->add($updateInterval);
 		}
 
-		$confirmed_users = $this->context->authenticator->getCountConfirmedUsers();
-		$stats = $this->context->orders->calculateOrderStats();
-		\Nette\Diagnostics\Debugger::dump($stats);
-
 		if ($nextUpdateTime <= $now) {
-			// amount of registered users, amount of active orders, amount of executed orders to date
-			\Nette\Diagnostics\Debugger::dump("Updating!");
 			$this->context->values->updateDateTime("globalStats", "lastUpdateTime", $now);
+
+			$confirmedUsers = $this->context->authenticator->getCountConfirmedUsers();
+			$this->context->values->update("globalStats", "confirmedUsers", $confirmedUsers);
+
+			$stats = $this->context->orders->calculateOrderStats();
+			foreach ($stats as $key => $value) {
+				$this->context->values->update("globalStats", $key, $value);
+			}
 		}
 	}
 

--- a/www/app/presenters/ApiPresenter.php
+++ b/www/app/presenters/ApiPresenter.php
@@ -12,16 +12,14 @@ class ApiPresenter extends BasePresenter {
 	 */
 	public function renderCron() {
 		$initialTime = time();
-
 		$this->possiblyUpdateGlobalSummaryStats();
 
-		// STOPSHIP(mattfaus): DEBUG ONLY
 		// Check and execute active orders every 3 seconds
-		// while(time() - $initialTime < 55){
-		// 	$this->checkActiveOrders();
-		// 	// TODO(mattfaus): We should sleep less if order execution took a long time
-		// 	sleep(3);
-		// }
+		while(time() - $initialTime < 55){
+			$this->checkActiveOrders();
+			// TODO(mattfaus): We should sleep less if order execution took a long time
+			sleep(3);
+		}
 	}
 
 	private function checkActiveOrders() {

--- a/www/app/presenters/HomepagePresenter.php
+++ b/www/app/presenters/HomepagePresenter.php
@@ -6,6 +6,9 @@
 class HomepagePresenter extends BasePresenter {
 
 	public function renderDefault($code = NULL) {
+		// TODO(mattfaus): memcache this
+		$this->template->globalStats = $this->context->values->getGroup("globalStats");
+		$this->template->globalStats["confirmedUsers"] = $this->context->values->get("globalStats", "confirmedUsers")->value;
 	}
 
 	public function renderOrders() {

--- a/www/app/templates/Homepage/default.latte
+++ b/www/app/templates/Homepage/default.latte
@@ -14,7 +14,7 @@
 	<p>CoinbaseOrders.com is home to {$globalStats["confirmedUsers"]} registered users </p>
 	<p>Who have bought {$globalStats["executedBuyBTCSum"]|number:2} BTC over {$globalStats["executedBuyCount"]} buy orders</p>
 	<p>...and have {$globalStats["activeBuyCount"]} buy orders open</p>
-	<p>...and have sold {$globalStats["executedSellBTCSum"]} BTC over {$globalStats["executedSellCount"]} sell orders</p>
+	<p>...and have sold {$globalStats["executedSellBTCSum"]|number:2} BTC over {$globalStats["executedSellCount"]} sell orders</p>
 	<p>...and have {$globalStats["activeSellCount"]} sell orders open</p>
 
 	<br/><br/><br/><br/><h2>Screenshot</h2>

--- a/www/app/templates/Homepage/default.latte
+++ b/www/app/templates/Homepage/default.latte
@@ -6,14 +6,20 @@
 	<h1>Place limit orders on your Coinbase account</h1>
 
 	<p>When price dips unexpectedly while I sleep, I want to make sure to get some discounted Bitcoins.</p>
-	
+
 	<p>Or sell a little when it skyrockets.</p>
-	
+
 	<a n:href="Sign:in" class="btn btn-success btn-large"><i class="icon-white icon-lock"></i> Sign up</a>
-	
+
+	<p>CoinbaseOrders.com is home to {$globalStats["confirmedUsers"]} registered users </p>
+	<p>Who have bought {$globalStats["executedBuyBTCSum"]|number:2} BTC over {$globalStats["executedBuyCount"]} buy orders</p>
+	<p>...and have {$globalStats["activeBuyCount"]} buy orders open</p>
+	<p>...and have sold {$globalStats["executedSellBTCSum"]} BTC over {$globalStats["executedSellCount"]} sell orders</p>
+	<p>...and have {$globalStats["activeSellCount"]} sell orders open</p>
+
 	<br/><br/><br/><br/><h2>Screenshot</h2>
 	<img src="img/orders-screen.png" style="width:40%" class="img-responsive"  />
-	
+
 {elseif isset($headerMessage)}
 	{if $headerMessage->getName() == 'a' && $headerMessage->getText() == 'Connect to Coinbase'}
 		<p>Now you need to connect to Coinbase so that you can place Buy and Sell limit orders.</p>
@@ -22,8 +28,8 @@
 
 	{if $headerMessage->getName() == 'span'}
 		Please check your email for verification link. If you didn't get one, write me at tom@coinbaseorders.com
-	{/if}		
-		
+	{/if}
+
 {else}
 	<p>You can place orders now.</p>
 	<a n:href="Homepage:orders, 'OrdersGrid-filter[status]' => 'ACTIVE'" class="btn btn-success btn-large"><i class="icon-white icon-screenshot"></i> See and place orders</a>
@@ -34,10 +40,10 @@
 		<li>AFTER you verify your Coinbase account and place an order, you can't place a second one until the first order is completed (4-5 days)</li>
 		<li>If you have done this before on Coinbase and your account is fully established - you can place as many orders as you like</li>
 	</ul>
-	
+
 	<br/><h2>Price/orders are checked about every second</h2>
-	<p>This ensures fast response when price drops for a small period of time.</p>	
-	
+	<p>This ensures fast response when price drops for a small period of time.</p>
+
 	<br/><h2>Upcoming features</h2>
 	<ul>
 		<li><strike>Order confirmation dialog</strike> DONE</li>
@@ -45,7 +51,7 @@
 		<li>Entering amount to buy in USD</li>
 		<li>Have ideas? Email me <a href="mailto:tom@coinbaseorders.com">tom@coinbaseorders.com</a></li>
 	</ul>
-	
+
 	<br/><h2>Contribute (Code or Coins)</h2>
 	<p>I think Bitcoin is the most important thing to happen in next 5 years. I'll do what I can to support Bitcoin community and make things easier for everyone.</p>
 
@@ -53,11 +59,11 @@
 
 	<p>Alternatively, please consider a small donation. Direct address is 1NNcg12tPe2EHhg3Ese7hq6mEQ9W5W1ign</p>
 	<img src="https://chart.googleapis.com/chart?cht=qr&chl=bitcoin%3A1NNcg12tPe2EHhg3Ese7hq6mEQ9W5W1ign&choe=UTF-8&chs=200x200"/>
-	
+
 	<br/><h2>Discussion</h2>
 	<p>You can discuss ideas with the community at <a href="https://bitcointalk.org/index.php?topic=389638.0">Bitcoin Talk Forum</a>.</p>
-	
-	
+
+
 {/if}
 
 


### PR DESCRIPTION
Here is a screenshot of what this looks like. The screenshot does not include the fix to add `|number:2` to the `executedSellBTCSum`. I am not very good at making things pretty, so feel free to format however you want.  There are additional statistics available on the `$globalStats` object, as defined by the columns in the query inside `OrdersModels->calculateOrderStats()`.

![screen shot 2014-03-04 at 5 20 05 pm](https://f.cloud.github.com/assets/2415796/2328676/615efbd4-a404-11e3-9c38-dfb7581bb102.png)
